### PR TITLE
Feat: alternative sign-in without NextAuth plugin

### DIFF
--- a/postman/Web3 Login [local].postman_environment.json
+++ b/postman/Web3 Login [local].postman_environment.json
@@ -1,0 +1,21 @@
+{
+	"id": "d1e369e7-ac8c-4711-93e6-2d8e41f4891d",
+	"name": "Web3 Login",
+	"values": [
+		{
+			"key": "BASE_URL",
+			"value": "http://localhost:3000/api/v1",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "TOKEN",
+			"value": "",
+			"type": "any",
+			"enabled": true
+		}
+	],
+	"_postman_variable_scope": "environment",
+	"_postman_exported_at": "2023-05-26T22:59:55.812Z",
+	"_postman_exported_using": "Postman/10.14.6"
+}

--- a/postman/Web3 Login.postman_collection.json
+++ b/postman/Web3 Login.postman_collection.json
@@ -1,0 +1,75 @@
+{
+	"info": {
+		"_postman_id": "b91d3d8a-9b55-4011-afd3-fe2ced7327f0",
+		"name": "Web3 Login",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "18825054"
+	},
+	"item": [
+		{
+			"name": "Sign In",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"const responseJSON = pm.response.json();",
+							"pm.environment.set('TOKEN', responseJSON.token);"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"address\": \"14GgSVJ1unwjVw4CuMGXYz4P4yT1HzVqEDEiExhiCS84EGQo\",\n\t\"message\": \"Sign-in request for address 14GgSVJ1unwjVw4CuMGXYz4P4yT1HzVqEDEiExhiCS84EGQo.\",\n\t\"signature\": \"0xfc03197bd2110f613677913e3d52afbc1ecda9099109f01300a97acde7122d305d87d115cf173632319c6666d829a4585a45462cb3d2df5513f7d5a68c9f1785\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{BASE_URL}}/signin",
+					"host": [
+						"{{BASE_URL}}"
+					],
+					"path": [
+						"signin"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Secret",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{TOKEN}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{BASE_URL}}/secret",
+					"host": [
+						"{{BASE_URL}}"
+					],
+					"path": [
+						"secret"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/src/components/web3-login-button.tsx
+++ b/src/components/web3-login-button.tsx
@@ -27,15 +27,13 @@ export default function Web3LoginButton(props: Web3LoginButtonProps) {
                 address: accountAddress,
             }).then(async ({ signature }: { signature: string }) => {
                 // validate signature via API to obtain session
-                const response = await signIn('credentials', {
+                await signIn('credentials', {
                     address: accountAddress,
                     message,
                     signature,
                     redirect: true,
                     callbackUrl: '/secrets'
                 })
-
-                console.log('response', response)
             })
         }
     }, [wallet, accounts, props.message])

--- a/src/pages/api/v1/secret.ts
+++ b/src/pages/api/v1/secret.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { getServerSession } from "next-auth/next"
 import { authOptions } from "./[...nextauth]"
+import { getToken } from 'next-auth/jwt'
 
 type Data = {
   secret: string
@@ -15,9 +16,17 @@ const handler = async (
     return res.status(405).end()
   }
 
+  // Check either the session or Bearer token.
+  // 
+  // This approach allows experimentation with the API, however, in a production scenario
+  // this should ideally be either a session or a token verification, depending on the use case.
+  // 
+  // This logic would normally be placed in a middleware method such that it can be reused 
+  // for multiple protected API routes.
   const session = await getServerSession(req, res, authOptions)
+  const token = await getToken({ req, secret: process.env.JWT_SECRET! })
 
-  if (!session) {
+  if (!session && !token) {
     return res.status(401).end()
   }
 

--- a/src/pages/api/v1/signin.ts
+++ b/src/pages/api/v1/signin.ts
@@ -1,0 +1,47 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { cryptoWaitReady } from '@polkadot/util-crypto'
+import { isValidSignature } from '@/utils/signature'
+import { encode } from 'next-auth/jwt'
+
+type Data = {
+  token?: string
+  error?: string
+}
+
+const handler = async (
+  req: NextApiRequest,
+  res: NextApiResponse<Data>
+) => {
+  const { message, signature, address } = req.body
+
+  if (!message || !signature || !address) {
+    return res.status(400).json({
+      error: 'Missing parameters',
+    })
+  }
+
+  await cryptoWaitReady()
+  const isValid = isValidSignature(message, signature, address)
+
+  if (!isValid) {
+    return res.status(401).json({
+      error: 'Invalid signature',
+    })
+  }
+
+  // NOTE: this assumes that the JWT_SECRET is available in the process environment
+  const token = await encode({
+    secret: process.env.JWT_SECRET!,
+    token: {
+      user: {
+        id: address,
+      },
+    },
+  })
+  
+  res.status(200).json({
+    token,
+  })
+}
+
+export default handler


### PR DESCRIPTION
Closes #2 

---

What Changed?

- Added a route `/api/v1/signin` which does the same message signature verification as current implementation, however, doesn't require the explicit use of the `NextAuth`plugin and can use any `jwt` library. The request also doesn't set any sessions but simply responds back with a JWT string.
- Added a sample [Postman](https://www.postman.com/) collection and environment for testing the API directly.
- Extended the `/api/v1/secret` route to check either the session (current) or the `Authorization` header JWT.

How to test?

- A simple API test can be run with the Postman collection and environment provided.
